### PR TITLE
Implement `EveryPromiseResolver`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@run-z/project-config": "^0.18.0",
     "@swc/core": "^1.3.56",
     "@swc/jest": "^0.2.26",
+    "@types/node": "^18.16.5",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "eslint": "^8.40.0",

--- a/src/every-promise-resolver.ts
+++ b/src/every-promise-resolver.ts
@@ -1,0 +1,105 @@
+import { lazyValue, noop } from '@proc7ts/primitives';
+
+/**
+ * A resolver of every input promise that can be created later or not created at all.
+ *
+ * Promises to resolve can be passed to constructor, or {@link add added} later, but not before the resulting
+ * promise {@link whenDone created}.
+ *
+ * Creates the resulting promise only on demand.
+ *
+ * The methods of this object do not require `this` context and can be called as functions.
+ *
+ * @typeParam T - The type of value the input promises resolve to.
+ */
+export class EveryPromiseResolver<in out T = void> {
+
+  /**
+   * Adds promise(s) to resolve.
+   *
+   * Has no effect when the resulting promise already settled.
+   *
+   * Can be called before the promise created.
+   *
+   * Calling without arguments causes the {@link whenDone resulting promise} to resolve.
+   *
+   * @param promises - Promises to add to resolution.
+   */
+  readonly add: (this: void, ...promises: (T | PromiseLike<T>)[]) => this;
+
+  /**
+   * Rejects the resulting promise.
+   *
+   * Has no effect when the {@link whenDone resulting} promise already settled.
+   *
+   * Can be called before the resulting promise {@link whenDone created}.
+   *
+   * @param reason - Promise rejection reason.
+   */
+  readonly reject: (this: void, reason?: unknown) => void;
+
+  /**
+   * Creates a promise resolved when every {@link add added} promise resolved, or rejected when any of them rejected.
+   *
+   * The subsequent calls to this method return the same promise instance.
+   *
+   * @returns Resulting promise resolved to array of added promise resolutions.
+   */
+  readonly whenDone: (this: void) => Promise<T[]>;
+
+  /**
+   * Constructs every promise resolver.
+   *
+   * If no `promises` passed to constructor, then no promises to resolve will be added. This means that the
+   * {@link whenDone resulting promise} won't be settled until either {@link add}, or {@link reject} method called.
+   *
+   * @param promises - Promises to add to resolution initially.
+   */
+  constructor(...promises: (T | PromiseLike<T>)[]) {
+    let added: Promise<Awaited<T>[]> = Promise.resolve([]);
+    let done = false;
+    let addPromises = (promises: (T | PromiseLike<T>)[]): void => {
+      if (promises.length) {
+        added = Promise.all([added, Promise.all(promises)]).then(
+          (arrays: Awaited<T>[][]): Awaited<T>[] => arrays.flat(),
+        );
+      }
+      resolvePromise(added);
+      if (done) {
+        addPromises = noop;
+      }
+    };
+    let resolvePromise = (value: T[] | PromiseLike<T[]>): void => {
+      const promise = Promise.resolve(value);
+
+      promise.catch(noop);
+      buildPromise = () => promise;
+    };
+    let rejectPromise = (reason?: unknown): void => {
+      buildPromise = lazyValue(() => Promise.reject(reason));
+      addPromises = noop;
+      resolvePromise = noop;
+      rejectPromise = noop;
+    };
+    let buildPromise = lazyValue(
+      () => new Promise<T[]>((resolve, reject) => {
+          done = true;
+          resolvePromise = resolve;
+          rejectPromise = reject;
+        }),
+    );
+
+    this.add = (...promises) => {
+      addPromises(promises);
+
+      return this;
+    };
+    this.reject = reason => rejectPromise(reason);
+    this.whenDone = () => buildPromise();
+
+    if (promises.length) {
+      addPromises(promises);
+    }
+  }
+
+}

--- a/src/every-promise.resolver.spec.ts
+++ b/src/every-promise.resolver.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { EveryPromiseResolver } from './every-promise-resolver.js';
+
+describe('EveryPromiseResolver', () => {
+  let resolver: EveryPromiseResolver<string>;
+
+  beforeEach(() => {
+    resolver = new EveryPromiseResolver();
+  });
+
+  describe('add', () => {
+    it('resolves resulting promise before its construction', async () => {
+      resolver.add('foo');
+      resolver.add('bar');
+
+      const promise = resolver.whenDone();
+
+      expect(await promise).toEqual(['foo', 'bar']);
+      expect(promise).toBe(resolver.whenDone());
+    });
+    it('rejects resulting promise before its construction', async () => {
+      resolver.add(Promise.reject('foo'));
+      resolver.add('bar');
+
+      const promise = resolver.whenDone();
+
+      await expect(promise).rejects.toBe('foo');
+      expect(promise).toBe(resolver.whenDone());
+    });
+    it('resolves resulting promise after its construction', async () => {
+      const promise = resolver.whenDone();
+
+      resolver.add('foo', 'bar');
+      resolver.add('baz');
+
+      expect(await promise).toEqual(['foo', 'bar']);
+      expect(promise).toBe(resolver.whenDone());
+    });
+    it('rejects resulting promise after its construction', async () => {
+      const promise = resolver.whenDone();
+
+      resolver.add(Promise.reject('foo'));
+      resolver.add('bar');
+
+      await expect(promise).rejects.toBe('foo');
+      expect(promise).toBe(resolver.whenDone());
+    });
+    it('resolves resulting promise by another one', async () => {
+      const promise = resolver.whenDone();
+
+      resolver.add(Promise.resolve('foo'), Promise.resolve('bar'));
+      resolver.add(Promise.resolve('baz'));
+
+      expect(await promise).toEqual(['foo', 'bar']);
+      expect(promise).toBe(resolver.whenDone());
+    });
+    it('resolves resulting promise to empty array when called without parameters', async () => {
+      const promise = resolver.whenDone();
+
+      resolver.add();
+      expect(await promise).toEqual([]);
+      expect(promise).toBe(resolver.whenDone());
+    });
+    it('does not cause unresolved promise rejection before promise construction', async () => {
+      resolver.add(Promise.reject('foo'));
+
+      expect(await new Promise(resolve => setImmediate(resolve))).toBeUndefined();
+      await expect(resolver.whenDone()).rejects.toBe('foo');
+    });
+    it('does not cause unresolved promise rejection after promise construction', async () => {
+      const whenDone = resolver.whenDone();
+
+      resolver.add(Promise.reject('foo'));
+
+      await expect(whenDone).rejects.toBe('foo');
+      expect(await new Promise(resolve => setImmediate(resolve))).toBeUndefined();
+    });
+  });
+
+  describe('reject', () => {
+    let error1: Error;
+    let error2: Error;
+
+    beforeEach(() => {
+      error1 = new Error('Error 1');
+      error2 = new Error('Error 2');
+    });
+
+    it('rejects the promise before its construction', async () => {
+      resolver.reject(error1);
+      resolver.reject(error2);
+
+      const promise = resolver.whenDone();
+
+      await expect(promise).rejects.toBe(error1);
+      expect(promise).toBe(resolver.whenDone());
+    });
+    it('rejects the promise after its construction', async () => {
+      const promise = resolver.whenDone();
+
+      resolver.reject(error1);
+      resolver.reject(error2);
+
+      await expect(promise).rejects.toBe(error1);
+      expect(promise).toBe(resolver.whenDone());
+    });
+  });
+
+  describe('whenDone', () => {
+    it('builds the promise once', () => {
+      const promise = resolver.whenDone();
+
+      expect(resolver.whenDone()).toBe(promise);
+      expect(resolver.whenDone()).toBe(promise);
+      expect(resolver.whenDone()).toBe(promise);
+    });
+    it('resolves resulting promise when resolver constructed with parameters', async () => {
+      resolver = new EveryPromiseResolver('foo', 'bar');
+
+      const promise = resolver.whenDone();
+
+      expect(await promise).toEqual(['foo', 'bar']);
+      expect(promise).toBe(resolver.whenDone());
+    });
+  });
+});

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,7 +1,7 @@
 /**
- * @packageDocumentation
  * @module @proc7ts/async
  */
+export * from './every-promise-resolver.js';
 export * from './promise-resolver.js';
-export * from './semaphore.js';
 export * from './semaphore-revoke-error.js';
+export * from './semaphore.js';

--- a/src/promise-resolver.spec.ts
+++ b/src/promise-resolver.spec.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { asis } from '@proc7ts/primitives';
 import { PromiseResolver } from './promise-resolver.js';
 
 describe('PromiseResolver', () => {
@@ -70,7 +69,7 @@ describe('PromiseResolver', () => {
     it('does not cause unresolved promise rejection before promise construction', async () => {
       resolver.resolve(Promise.reject('foo'));
 
-      expect(await new Promise(resolve => setTimeout(resolve, 10))).toBeUndefined();
+      expect(await new Promise(resolve => setImmediate(resolve))).toBeUndefined();
       await expect(resolver.whenDone()).rejects.toBe('foo');
     });
     it('does not cause unresolved promise rejection after promise construction', async () => {
@@ -79,7 +78,7 @@ describe('PromiseResolver', () => {
       resolver.resolve(Promise.reject('foo'));
 
       await expect(whenDone).rejects.toBe('foo');
-      expect(await new Promise(resolve => setTimeout(resolve, 10))).toBeUndefined();
+      expect(await new Promise(resolve => setImmediate(resolve))).toBeUndefined();
     });
   });
 
@@ -98,7 +97,7 @@ describe('PromiseResolver', () => {
 
       const promise = resolver.whenDone();
 
-      expect(await promise.catch(asis)).toBe(error1);
+      await expect(promise).rejects.toBe(error1);
       expect(promise).toBe(resolver.whenDone());
     });
     it('rejects the promise after its construction', async () => {
@@ -107,12 +106,12 @@ describe('PromiseResolver', () => {
       resolver.reject(error1);
       resolver.reject(error2);
 
-      expect(await promise.catch(asis)).toBe(error1);
+      await expect(promise).rejects.toBe(error1);
       expect(promise).toBe(resolver.whenDone());
     });
   });
 
-  describe('promise', () => {
+  describe('whenDone', () => {
     it('builds the promise once', () => {
       const promise = resolver.whenDone();
 

--- a/src/semaphore-revoke-error.ts
+++ b/src/semaphore-revoke-error.ts
@@ -5,10 +5,7 @@ export class SemaphoreRevokeError extends Error {
 
   constructor(message = 'Semaphore revoked', options?: ErrorOptions) {
     super(message, options);
-  }
-
-  get name(): string {
-    return 'SemaphoreRevokeError';
+    this.name = 'SemaphoreRevokeError';
   }
 
 }

--- a/src/semaphore.ts
+++ b/src/semaphore.ts
@@ -5,7 +5,7 @@ import { SemaphoreRevokeError } from './semaphore-revoke-error.js';
 /**
  * [Semaphore](https://en.wikipedia.org/wiki/Semaphore_(programming)) instance.
  *
- * Permits preconfigured maximum simultaneous acquires.
+ * Permits pre-configured maximum simultaneous acquires.
  *
  * It is expected that each {@link acquire} is followed by corresponding {@link release}.
  */
@@ -57,7 +57,7 @@ export class Semaphore {
   /**
    * Semaphore supply.
    *
-   * No more locks can not be acquired one this supply cut off. All {@link Semaphore.acquire} method calls would
+   * No more locks can not be acquired one this supply cut off. All {@link Semaphore#acquire} method calls would
    * result to an error after that.
    */
   get supply(): Supply {
@@ -167,7 +167,7 @@ export class Semaphore {
  */
 export interface SemaphoreInit {
   /**
-   * The maximum simultaneous {@link Semaphore.acquire acquires} permitted. `1` by default.
+   * The maximum simultaneous {@link Semaphore#acquire acquires} permitted. `1` by default.
    */
   readonly maxPermits?: number | undefined;
 
@@ -179,7 +179,7 @@ export interface SemaphoreInit {
   /**
    * Explicit semaphore supply.
    *
-   * No more locks can not be acquired one this supply cut off. All {@link Semaphore.acquire} method calls would
+   * No more locks can not be acquired one this supply cut off. All {@link Semaphore#acquire} method calls would
    * result to an error after that.
    */
   readonly supply?: Supply | undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@run-z/project-config/tsconfig.lib.json",
   "compilerOptions": {
-    "outDir": "target/js"
+    "outDir": "target/js",
+    "types": []
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
- Add `EveryPromiseResolver`
- Add missing dev dependency required by TypeDoc
- Assign error name
- Export `EveryPromiseResolver`
- Refine doc
- Simplify `PromiseResolver` implementation
